### PR TITLE
refactor(core): cleanup deprecated SM api usage

### DIFF
--- a/addons/sourcemod/scripting/ExtraCommands.sp
+++ b/addons/sourcemod/scripting/ExtraCommands.sp
@@ -41,7 +41,7 @@ public Plugin myinfo =
 	name        = "Advanced Commands",
 	author      = "BotoX + Obus + maxime1907, .Rushaway",
 	description = "Adds extra commands for admins.",
-	version     = "2.7.13",
+	version     = "2.7.14",
 	url         = ""
 };
 
@@ -243,9 +243,6 @@ public void OnClientDisconnect(int client)
 {
 	g_bInBuyZone[client] = false;
 	g_bInfAmmo[client]   = false;
-
-	SDKUnhook(client, SDKHook_PreThink, OnPreThink);
-	SDKUnhook(client, SDKHook_PostThinkPost, OnPostThinkPost);
 }
 
 public void OnPreThink(int client)

--- a/addons/sourcemod/scripting/ExtraCommands.sp
+++ b/addons/sourcemod/scripting/ExtraCommands.sp
@@ -128,21 +128,6 @@ public void OnPluginStart()
 	}
 }
 
-public void OnPluginEnd()
-{
-	for (int i = 1; i <= MaxClients; i++)
-	{
-		SDKUnhook(i, SDKHook_PreThink, OnPreThink);
-		SDKUnhook(i, SDKHook_PostThinkPost, OnPostThinkPost);
-	}
-
-	if (g_hServerCanExecuteCmds != null)
-		delete g_hServerCanExecuteCmds;
-
-	if (g_hEntitiesListToKill != null)
-		delete g_hEntitiesListToKill;
-}
-
 public void OnMapStart()
 {
 	g_bInBuyZoneAll = false;


### PR DESCRIPTION
## Description
Cleanup of deprecated and unnecessary SourceMod API usage across plugins.

## Changes
- Removed manual `SDKUnhook` — hooks are automatically removed on entity destruction per SDKHook documentation

## References
- [SDKHook docs](https://sm.alliedmods.net/new-api/sdkhooks/SDKHook) — *"Unhooked automatically upon destruction/removal of the entity"*